### PR TITLE
Docker container doesn't expose the application

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -18,7 +18,7 @@ app.behind.proxy = false
 
 
 # The IP address on which to listen.
-http.addr =
+http.addr = 0.0.0.0
 
 # The port on which to listen.
 http.port = 9000


### PR DESCRIPTION
When I built a container, using the supplied Dockerfile, the application was not available via the browser. 
This fix binds the application to the host interface 0.0.0.0, instead of "localhost".

## Test

The container can now be built and run as follows:

```
docker build -t myspotontheweb/go-revel-docker:dev .
docker run -d --name revel -p 9000:9000 myspotontheweb/go-revel-docker:dev
```

And the webpage is exposed as expected 

- http://localhost:9000